### PR TITLE
Update links and simplify README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,8 @@
 # 🌟 Polkadot Hackathon Survival Guide 🌟
 
-## 👋 Introduction
+Welcome to the **Polkadot Hackathon Survival Guide**!  Whether you're a **blockchain pro** or just starting with **Polkadot**, this guide has all the essential info, tips, and resources to help you in your journey building on Polkadot. ✨
 
-Welcome to the **Polkadot Hackathon Survival Guide**! This resource is your go-to companion for navigating the world of **Polkadot development** during the hackathon. 
-
-Whether you're a **blockchain pro** or just starting with **Polkadot**, this guide has all the essential info, tips, and resources to help you shine. ✨
-
-From setting up your **development environment** to **presenting your project**, we’ve got you covered. 
-
-## 🌟 Development Pathways
-
-Developers can follow different paths to build applications and core blockchain functionality. Each pathway fits different **project types** and **skill levels**, all contributing to the **broader Polkadot ecosystem**. 
-
-The Polkadot ecosystem provides multiple development pathways:
+From setting up your **development environment** to **presenting your project**, we’ve got you covered. The Polkadot ecosystem provides multiple development pathways:
 
 <img width="1109" alt="image" src="https://github.com/user-attachments/assets/5c5bf50a-1906-4f04-9478-0d3bcc70649b" />
 
@@ -20,8 +10,6 @@ The Polkadot ecosystem provides multiple development pathways:
 👉 For builders looking to deploy smart contract based applications to Polkadot, head straight to the [resource page for Polkadot Hub developers](./polkadot-hub-devs.md)
 
 👉 For builders looking to create custom blockchains with the Polkadot SDK, check out the dedicated [resource for parachain developers](./polkadot-parachain-devs.md).
-
-Good luck, and **happy hacking!** 🚀
 
 ## 🎓 More Resources
 

--- a/README.md
+++ b/README.md
@@ -29,3 +29,10 @@ Here are some additional resources that can help you during the hackathon:
 
 - [**Polkadot Open Source Stack**](https://wiki.polkadot.network/build/build-open-source/) 🌟 - a list of open-source tools, libraries, and frameworks that were funded by [Web3 Foundation grants program](https://grants.web3.foundation/) and the Polkadot treasury 
 - [**Awesome DOT Repository**](https://github.com/haquefardeen/awesome-dot) 📚 - a list of resources and projects of the Polkadot and Kusama ecosystem
+
+## 💰 Post-hackathon support
+
+Looking to get funding post-hackathon? Here's a list of different grant opportunities in the Polkadot:
+- [W3F Grants](https://grants.web3.foundation/docs/Process/how-to-apply): up to >$100k in funding
+- [Opensource grants](https://github.com/PolkadotOpenSourceGrants): up to $30k in funding
+- [Fast grants](https://github.com/Polkadot-Fast-Grants/apply): up to $10k in funding

--- a/polkadot-hub-devs.md
+++ b/polkadot-hub-devs.md
@@ -64,7 +64,7 @@ Jumpstart your **smart contract dApp** with these templates:
 
 - [**create-polkadot-dapp**](https://www.npmjs.com/package/create-polkadot-dapp?activeTab=readme) - a scaffolding tool to generate project boilerplates. Explore the `react-solidity` template located in the `templates` folder which comes pre-configured with **React, Tailwind CSS, and Ethers.js** for frontend interaction with your smart contracts
 
-- [**rust-contract-template**](https://github.com/paritytech/rust-contract-template/) - a template for writing Rust contracts designed to compile to PolkaVM.
+- [**hardhat-polkadot-example**](https://github.com/UtkarshBhardwaj007/hardhat-polkadot-example) - a demo for how to use Hardhat with Polkadot.
 
 ### 🧙 Alternative Smart Contract Languages
 

--- a/polkadot-hub-devs.md
+++ b/polkadot-hub-devs.md
@@ -2,6 +2,8 @@
 
 Polkadot enables **smart contract deployment** via **PolkaVM**. This allows using familiar **Ethereum tools** and **libraries** while leveraging Polkadot’s robust ecosystem. **PolkaVM** is live on the Polkadot testnet Westend. ✅
 
+*Refer to the [**known issues**](https://docs.google.com/document/d/1j5hnQZRqlbVagW28dC24OVAF8uRih5jWubBxy5PlMYc/edit?usp=sharing) document if you're running into issues deploying contracts or using any of the tools below.*
+
 ### 📚 Development Environments
 
 There are multiple development environments already available for Polkadot smart contract development. Here are some of the most popular ones:


### PR DESCRIPTION
The Rust contract template is confusing to have. I propose to replace it with the hardhat example Utkarsh built for ETHLisbon and simplify the README to make it more to the point.