### PR TITLE
add DevContainer to smart contracts hackathon guide

### DIFF
--- a/polkadot-hub-devs.md
+++ b/polkadot-hub-devs.md
@@ -9,7 +9,7 @@ Please provide **feedback** on your experience deploying smart contracts on Polk
 ### 🚀 Quick Start with DevContainers
 
 - To speed things up and have your "batteries included" dev environment, you can use [DevContainers](https://code.visualstudio.com/docs/devcontainers/containers). They are regularly maintained and tested by the ecosystem professionals. You can find the configuration for Polkadot smart contract development in the [smart-contracts-devcontainer](https://github.com/paritytech/smart-contracts-devcontainer) repository.
-- To use the DevContainer, you need to have Docker installed on your machine and running. You can download Docker from the [Docker website](https://www.docker.com/products/docker-desktop/). You also need the Vscode extension for DevContainers. You can install it from the [VSCode Marketplace](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers).
+- To use it, you need to have [Docker](https://www.docker.com/products/docker-desktop) or [Podman](https://podman.io/docs/installation) installed and running on your machine. You also need the Vscode extension for DevContainers. You can install it from the [VSCode Marketplace](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers).
 - Once Docker is running and the DevContainers extension is installed, simply create a new folder and run the following command to get started:
 
 ```bash


### PR DESCRIPTION
DevContainers will help hackers get started without having to read any documentation in under 5 mins. Adding this to the hackathon guide.

Closes #63 