### PR TITLE
Add `.lycheeignore` file

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,0 +1,1 @@
+https://www.npmjs.com/package/create-polkadot-dapp


### PR DESCRIPTION
This pull request adds a new entry to the `.lycheeignore` file to exclude a specific npm package URL from link checking.

* [`.lycheeignore`](diffhunk://#diff-fafe8d160920b6bd97b3c5235607969496ac0550eb4eeb9833393711fc210f18R1): Added `https://www.npmjs.com/package/create-polkadot-dapp` to the ignore list for link checking.